### PR TITLE
Trim trailing spaces in EPL 92-15 team names.

### DIFF
--- a/EPL 1992 - 2015/tables/epl-00-01.json
+++ b/EPL 1992 - 2015/tables/epl-00-01.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Manchester United ",
+      "team":"Manchester United",
       "played":38,
       "wins":24,
       "draws":8,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Manchester City ",
+      "team":"Manchester City",
       "played":38,
       "wins":8,
       "draws":10,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Coventry City ",
+      "team":"Coventry City",
       "played":38,
       "wins":8,
       "draws":10,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Bradford City ",
+      "team":"Bradford City",
       "played":38,
       "wins":5,
       "draws":11,

--- a/EPL 1992 - 2015/tables/epl-01-02.json
+++ b/EPL 1992 - 2015/tables/epl-01-02.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Arsenal ",
+      "team":"Arsenal",
       "played":38,
       "wins":26,
       "draws":9,
@@ -14,7 +14,7 @@
    },
    {
       "rank":2,
-      "team":"Liverpool ",
+      "team":"Liverpool",
       "played":38,
       "wins":24,
       "draws":8,
@@ -27,7 +27,7 @@
    },
    {
       "rank":3,
-      "team":"Manchester United ",
+      "team":"Manchester United",
       "played":38,
       "wins":24,
       "draws":5,
@@ -40,7 +40,7 @@
    },
    {
       "rank":4,
-      "team":"Newcastle United ",
+      "team":"Newcastle United",
       "played":38,
       "wins":21,
       "draws":8,
@@ -53,7 +53,7 @@
    },
    {
       "rank":5,
-      "team":"Leeds United ",
+      "team":"Leeds United",
       "played":38,
       "wins":18,
       "draws":12,
@@ -66,7 +66,7 @@
    },
    {
       "rank":6,
-      "team":"Chelsea ",
+      "team":"Chelsea",
       "played":38,
       "wins":17,
       "draws":13,
@@ -79,7 +79,7 @@
    },
    {
       "rank":7,
-      "team":"West Ham United ",
+      "team":"West Ham United",
       "played":38,
       "wins":15,
       "draws":8,
@@ -92,7 +92,7 @@
    },
    {
       "rank":8,
-      "team":"Aston Villa ",
+      "team":"Aston Villa",
       "played":38,
       "wins":12,
       "draws":14,
@@ -105,7 +105,7 @@
    },
    {
       "rank":9,
-      "team":"Tottenham Hotspur ",
+      "team":"Tottenham Hotspur",
       "played":38,
       "wins":14,
       "draws":8,
@@ -118,7 +118,7 @@
    },
    {
       "rank":10,
-      "team":"Blackburn Rovers ",
+      "team":"Blackburn Rovers",
       "played":38,
       "wins":12,
       "draws":10,
@@ -131,7 +131,7 @@
    },
    {
       "rank":11,
-      "team":"Southampton ",
+      "team":"Southampton",
       "played":38,
       "wins":12,
       "draws":9,
@@ -144,7 +144,7 @@
    },
    {
       "rank":12,
-      "team":"Middlesbrough ",
+      "team":"Middlesbrough",
       "played":38,
       "wins":12,
       "draws":9,
@@ -157,7 +157,7 @@
    },
    {
       "rank":13,
-      "team":"Fulham ",
+      "team":"Fulham",
       "played":38,
       "wins":10,
       "draws":14,
@@ -170,7 +170,7 @@
    },
    {
       "rank":14,
-      "team":"Charlton Athletic ",
+      "team":"Charlton Athletic",
       "played":38,
       "wins":10,
       "draws":14,
@@ -183,7 +183,7 @@
    },
    {
       "rank":15,
-      "team":"Everton ",
+      "team":"Everton",
       "played":38,
       "wins":11,
       "draws":10,
@@ -196,7 +196,7 @@
    },
    {
       "rank":16,
-      "team":"Bolton Wanderers ",
+      "team":"Bolton Wanderers",
       "played":38,
       "wins":9,
       "draws":13,
@@ -209,7 +209,7 @@
    },
    {
       "rank":17,
-      "team":"Sunderland ",
+      "team":"Sunderland",
       "played":38,
       "wins":10,
       "draws":10,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Ipswich Town ",
+      "team":"Ipswich Town",
       "played":38,
       "wins":9,
       "draws":9,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Derby County ",
+      "team":"Derby County",
       "played":38,
       "wins":8,
       "draws":6,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Leicester City ",
+      "team":"Leicester City",
       "played":38,
       "wins":5,
       "draws":13,

--- a/EPL 1992 - 2015/tables/epl-02-03.json
+++ b/EPL 1992 - 2015/tables/epl-02-03.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Manchester United !Manchester United *(C)*",
+      "team":"Manchester United",
       "played":38,
       "wins":25,
       "draws":8,
@@ -14,7 +14,7 @@
    },
    {
       "rank":2,
-      "team":"Arsenal !Arsenal",
+      "team":"Arsenal",
       "played":38,
       "wins":23,
       "draws":9,
@@ -27,7 +27,7 @@
    },
    {
       "rank":3,
-      "team":"Newcastle United !Newcastle United",
+      "team":"Newcastle United",
       "played":38,
       "wins":21,
       "draws":6,
@@ -40,7 +40,7 @@
    },
    {
       "rank":4,
-      "team":"Chelsea !Chelsea",
+      "team":"Chelsea",
       "played":38,
       "wins":19,
       "draws":10,
@@ -53,7 +53,7 @@
    },
    {
       "rank":5,
-      "team":"Liverpool !Liverpool",
+      "team":"Liverpool",
       "played":38,
       "wins":18,
       "draws":10,
@@ -66,7 +66,7 @@
    },
    {
       "rank":6,
-      "team":"Blackburn Rovers !Blackburn Rovers",
+      "team":"Blackburn Rovers",
       "played":38,
       "wins":16,
       "draws":12,
@@ -79,7 +79,7 @@
    },
    {
       "rank":7,
-      "team":"Everton !Everton",
+      "team":"Everton",
       "played":38,
       "wins":17,
       "draws":8,
@@ -92,7 +92,7 @@
    },
    {
       "rank":8,
-      "team":"Southampton !Southampton",
+      "team":"Southampton",
       "played":38,
       "wins":13,
       "draws":13,
@@ -105,7 +105,7 @@
    },
    {
       "rank":9,
-      "team":"Manchester City !Manchester City",
+      "team":"Manchester City",
       "played":38,
       "wins":15,
       "draws":6,
@@ -118,7 +118,7 @@
    },
    {
       "rank":10,
-      "team":"Tottenham Hotspur !Tottenham Hotspur",
+      "team":"Tottenham Hotspur",
       "played":38,
       "wins":14,
       "draws":8,
@@ -131,7 +131,7 @@
    },
    {
       "rank":11,
-      "team":"Middlesbrough !Middlesbrough",
+      "team":"Middlesbrough",
       "played":38,
       "wins":13,
       "draws":10,
@@ -144,7 +144,7 @@
    },
    {
       "rank":12,
-      "team":"Charlton Athletic !Charlton Athletic",
+      "team":"Charlton Athletic",
       "played":38,
       "wins":14,
       "draws":7,
@@ -157,7 +157,7 @@
    },
    {
       "rank":13,
-      "team":"Birmingham City !Birmingham City",
+      "team":"Birmingham City",
       "played":38,
       "wins":13,
       "draws":9,
@@ -170,7 +170,7 @@
    },
    {
       "rank":14,
-      "team":"Fulham !Fulham",
+      "team":"Fulham",
       "played":38,
       "wins":13,
       "draws":9,
@@ -183,7 +183,7 @@
    },
    {
       "rank":15,
-      "team":"Leeds United !Leeds United",
+      "team":"Leeds United",
       "played":38,
       "wins":14,
       "draws":5,
@@ -196,7 +196,7 @@
    },
    {
       "rank":16,
-      "team":"Aston Villa !Aston Villa",
+      "team":"Aston Villa",
       "played":38,
       "wins":12,
       "draws":9,
@@ -209,7 +209,7 @@
    },
    {
       "rank":17,
-      "team":"Bolton Wanderers !Bolton Wanderers",
+      "team":"Bolton Wanderers",
       "played":38,
       "wins":10,
       "draws":14,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"West Ham United !West Ham United *(R)*",
+      "team":"West Ham United",
       "played":38,
       "wins":10,
       "draws":12,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"West Bromwich Albion !West Bromwich Albion *(R)*",
+      "team":"West Bromwich Albion",
       "played":38,
       "wins":6,
       "draws":8,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Sunderland !Sunderland *(R)*",
+      "team":"Sunderland",
       "played":38,
       "wins":4,
       "draws":7,

--- a/EPL 1992 - 2015/tables/epl-03-04.json
+++ b/EPL 1992 - 2015/tables/epl-03-04.json
@@ -13,7 +13,7 @@
    },
    {
       "rank":2,
-      "team":"Chelsea ",
+      "team":"Chelsea",
       "played":38,
       "wins":24,
       "draws":7,
@@ -37,7 +37,7 @@
    },
    {
       "rank":4,
-      "team":"Liverpool ",
+      "team":"Liverpool",
       "played":38,
       "wins":16,
       "draws":12,
@@ -97,7 +97,7 @@
    },
    {
       "rank":9,
-      "team":"Fulham ",
+      "team":"Fulham",
       "played":38,
       "wins":14,
       "draws":10,
@@ -121,7 +121,7 @@
    },
    {
       "rank":11,
-      "team":"Middlesbrough ",
+      "team":"Middlesbrough",
       "played":38,
       "wins":13,
       "draws":9,
@@ -133,7 +133,7 @@
    },
    {
       "rank":12,
-      "team":"Southampton ",
+      "team":"Southampton",
       "played":38,
       "wins":12,
       "draws":11,
@@ -145,7 +145,7 @@
    },
    {
       "rank":13,
-      "team":"Portsmouth ",
+      "team":"Portsmouth",
       "played":38,
       "wins":12,
       "draws":9,
@@ -205,7 +205,7 @@
    },
    {
       "rank":18,
-      "team":"Leicester City ",
+      "team":"Leicester City",
       "played":38,
       "wins":6,
       "draws":15,

--- a/EPL 1992 - 2015/tables/epl-04-05.json
+++ b/EPL 1992 - 2015/tables/epl-04-05.json
@@ -73,7 +73,7 @@
    },
    {
       "rank":7,
-      "team":"Middlesbrough ",
+      "team":"Middlesbrough",
       "played":38,
       "wins":14,
       "draws":13,
@@ -85,7 +85,7 @@
    },
    {
       "rank":8,
-      "team":"Manchester City ",
+      "team":"Manchester City",
       "played":38,
       "wins":13,
       "draws":13,
@@ -133,7 +133,7 @@
    },
    {
       "rank":12,
-      "team":"Birmingham City ",
+      "team":"Birmingham City",
       "played":38,
       "wins":11,
       "draws":12,
@@ -169,7 +169,7 @@
    },
    {
       "rank":15,
-      "team":"Blackburn Rovers ",
+      "team":"Blackburn Rovers",
       "played":38,
       "wins":9,
       "draws":15,

--- a/EPL 1992 - 2015/tables/epl-05-06.json
+++ b/EPL 1992 - 2015/tables/epl-05-06.json
@@ -37,7 +37,7 @@
    },
    {
       "rank":4,
-      "team":"Arsenal ",
+      "team":"Arsenal",
       "played":38,
       "wins":20,
       "draws":7,
@@ -49,7 +49,7 @@
    },
    {
       "rank":5,
-      "team":"Tottenham Hotspur ",
+      "team":"Tottenham Hotspur",
       "played":38,
       "wins":18,
       "draws":11,
@@ -73,7 +73,7 @@
    },
    {
       "rank":7,
-      "team":"Newcastle United ",
+      "team":"Newcastle United",
       "played":38,
       "wins":17,
       "draws":7,
@@ -85,7 +85,7 @@
    },
    {
       "rank":8,
-      "team":"Bolton Wanderers ",
+      "team":"Bolton Wanderers",
       "played":38,
       "wins":15,
       "draws":11,
@@ -97,7 +97,7 @@
    },
    {
       "rank":9,
-      "team":"West Ham United ",
+      "team":"West Ham United",
       "played":38,
       "wins":16,
       "draws":7,
@@ -145,7 +145,7 @@
    },
    {
       "rank":13,
-      "team":"Charlton Athletic ",
+      "team":"Charlton Athletic",
       "played":38,
       "wins":13,
       "draws":8,
@@ -169,7 +169,7 @@
    },
    {
       "rank":15,
-      "team":"Manchester City ",
+      "team":"Manchester City",
       "played":38,
       "wins":13,
       "draws":4,

--- a/EPL 1992 - 2015/tables/epl-06-07.json
+++ b/EPL 1992 - 2015/tables/epl-06-07.json
@@ -13,7 +13,7 @@
    },
    {
       "rank":2,
-      "team":"Chelsea ",
+      "team":"Chelsea",
       "played":38,
       "wins":24,
       "draws":11,
@@ -25,7 +25,7 @@
    },
    {
       "rank":3,
-      "team":"Liverpool ",
+      "team":"Liverpool",
       "played":38,
       "wins":20,
       "draws":8,
@@ -37,7 +37,7 @@
    },
    {
       "rank":4,
-      "team":"Arsenal ",
+      "team":"Arsenal",
       "played":38,
       "wins":19,
       "draws":11,
@@ -49,7 +49,7 @@
    },
    {
       "rank":5,
-      "team":"Tottenham Hotspur ",
+      "team":"Tottenham Hotspur",
       "played":38,
       "wins":17,
       "draws":9,
@@ -61,7 +61,7 @@
    },
    {
       "rank":6,
-      "team":"Everton ",
+      "team":"Everton",
       "played":38,
       "wins":15,
       "draws":13,
@@ -73,7 +73,7 @@
    },
    {
       "rank":7,
-      "team":"Bolton Wanderers ",
+      "team":"Bolton Wanderers",
       "played":38,
       "wins":16,
       "draws":8,
@@ -157,7 +157,7 @@
    },
    {
       "rank":14,
-      "team":"Manchester City ",
+      "team":"Manchester City",
       "played":38,
       "wins":11,
       "draws":9,
@@ -169,7 +169,7 @@
    },
    {
       "rank":15,
-      "team":"West Ham United ",
+      "team":"West Ham United",
       "played":38,
       "wins":12,
       "draws":5,
@@ -181,7 +181,7 @@
    },
    {
       "rank":16,
-      "team":"Fulham !Fulham",
+      "team":"Fulham",
       "played":38,
       "wins":8,
       "draws":15,
@@ -193,7 +193,7 @@
    },
    {
       "rank":17,
-      "team":"Wigan Athletic ",
+      "team":"Wigan Athletic",
       "played":38,
       "wins":10,
       "draws":8,
@@ -217,7 +217,7 @@
    },
    {
       "rank":19,
-      "team":"Charlton Athletic ",
+      "team":"Charlton Athletic",
       "played":38,
       "wins":8,
       "draws":10,

--- a/EPL 1992 - 2015/tables/epl-08-09.json
+++ b/EPL 1992 - 2015/tables/epl-08-09.json
@@ -53,7 +53,7 @@
    },
    {
       "rank":5,
-      "team":"Everton ",
+      "team":"Everton",
       "played":38,
       "wins":17,
       "draws":12,
@@ -105,7 +105,7 @@
    },
    {
       "rank":9,
-      "team":"West Ham United ",
+      "team":"West Ham United",
       "played":38,
       "wins":14,
       "draws":9,
@@ -118,7 +118,7 @@
    },
    {
       "rank":10,
-      "team":"Manchester City ",
+      "team":"Manchester City",
       "played":38,
       "wins":15,
       "draws":5,
@@ -131,7 +131,7 @@
    },
    {
       "rank":11,
-      "team":"Wigan Athletic ",
+      "team":"Wigan Athletic",
       "played":38,
       "wins":12,
       "draws":9,
@@ -144,7 +144,7 @@
    },
    {
       "rank":12,
-      "team":"Stoke City ",
+      "team":"Stoke City",
       "played":38,
       "wins":12,
       "draws":9,
@@ -170,7 +170,7 @@
    },
    {
       "rank":14,
-      "team":"Portsmouth ",
+      "team":"Portsmouth",
       "played":38,
       "wins":10,
       "draws":11,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Newcastle United ",
+      "team":"Newcastle United",
       "played":38,
       "wins":7,
       "draws":13,

--- a/EPL 1992 - 2015/tables/epl-09-10.json
+++ b/EPL 1992 - 2015/tables/epl-09-10.json
@@ -27,7 +27,7 @@
    },
    {
       "rank":3,
-      "team":"Arsenal ",
+      "team":"Arsenal",
       "played":38,
       "wins":23,
       "draws":6,
@@ -40,7 +40,7 @@
    },
    {
       "rank":4,
-      "team":"Tottenham Hotspur ",
+      "team":"Tottenham Hotspur",
       "played":38,
       "wins":21,
       "draws":7,
@@ -53,7 +53,7 @@
    },
    {
       "rank":5,
-      "team":"Manchester City ",
+      "team":"Manchester City",
       "played":38,
       "wins":18,
       "draws":13,
@@ -92,7 +92,7 @@
    },
    {
       "rank":8,
-      "team":"Everton ",
+      "team":"Everton",
       "played":38,
       "wins":16,
       "draws":13,
@@ -131,7 +131,7 @@
    },
    {
       "rank":11,
-      "team":"Stoke City ",
+      "team":"Stoke City",
       "played":38,
       "wins":11,
       "draws":14,
@@ -196,7 +196,7 @@
    },
    {
       "rank":16,
-      "team":"Wigan Athletic ",
+      "team":"Wigan Athletic",
       "played":38,
       "wins":9,
       "draws":9,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Hull City ",
+      "team":"Hull City",
       "played":38,
       "wins":6,
       "draws":12,

--- a/EPL 1992 - 2015/tables/epl-10-11.json
+++ b/EPL 1992 - 2015/tables/epl-10-11.json
@@ -73,7 +73,7 @@
    },
    {
       "rank":7,
-      "team":"Everton ",
+      "team":"Everton",
       "played":38,
       "wins":13,
       "draws":15,
@@ -97,7 +97,7 @@
    },
    {
       "rank":9,
-      "team":"Aston Villa ",
+      "team":"Aston Villa",
       "played":38,
       "wins":12,
       "draws":12,
@@ -181,7 +181,7 @@
    },
    {
       "rank":16,
-      "team":"Wigan Athletic ",
+      "team":"Wigan Athletic",
       "played":38,
       "wins":9,
       "draws":15,
@@ -217,7 +217,7 @@
    },
    {
       "rank":19,
-      "team":"Blackpool !Blackpool",
+      "team":"Blackpool",
       "played":38,
       "wins":10,
       "draws":9,

--- a/EPL 1992 - 2015/tables/epl-11-12.json
+++ b/EPL 1992 - 2015/tables/epl-11-12.json
@@ -37,7 +37,7 @@
    },
    {
       "rank":4,
-      "team":"Tottenham Hotspur ",
+      "team":"Tottenham Hotspur",
       "played":38,
       "wins":20,
       "draws":9,
@@ -73,7 +73,7 @@
    },
    {
       "rank":7,
-      "team":"Everton ",
+      "team":"Everton",
       "played":38,
       "wins":15,
       "draws":11,
@@ -97,7 +97,7 @@
    },
    {
       "rank":9,
-      "team":"Fulham ",
+      "team":"Fulham",
       "played":38,
       "wins":14,
       "draws":10,
@@ -121,7 +121,7 @@
    },
    {
       "rank":11,
-      "team":"Swansea City ",
+      "team":"Swansea City",
       "played":38,
       "wins":12,
       "draws":11,
@@ -169,7 +169,7 @@
    },
    {
       "rank":15,
-      "team":"Wigan Athletic ",
+      "team":"Wigan Athletic",
       "played":38,
       "wins":11,
       "draws":10,
@@ -193,7 +193,7 @@
    },
    {
       "rank":17,
-      "team":"Queens Park Rangers ",
+      "team":"Queens Park Rangers",
       "played":38,
       "wins":10,
       "draws":7,

--- a/EPL 1992 - 2015/tables/epl-13-14.json
+++ b/EPL 1992 - 2015/tables/epl-13-14.json
@@ -121,7 +121,7 @@
    },
    {
       "rank":11,
-      "team":"Crystal Palace ",
+      "team":"Crystal Palace",
       "played":38,
       "wins":13,
       "draws":6,

--- a/EPL 1992 - 2015/tables/epl-92-93.json
+++ b/EPL 1992 - 2015/tables/epl-92-93.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Manchester United ",
+      "team":"Manchester United",
       "played":42,
       "wins":24,
       "draws":12,
@@ -14,7 +14,7 @@
    },
    {
       "rank":2,
-      "team":"Aston Villa ",
+      "team":"Aston Villa",
       "played":42,
       "wins":21,
       "draws":11,
@@ -27,7 +27,7 @@
    },
    {
       "rank":3,
-      "team":"Norwich City ",
+      "team":"Norwich City",
       "played":42,
       "wins":21,
       "draws":9,
@@ -40,7 +40,7 @@
    },
    {
       "rank":4,
-      "team":"Blackburn Rovers ",
+      "team":"Blackburn Rovers",
       "played":42,
       "wins":20,
       "draws":11,
@@ -53,7 +53,7 @@
    },
    {
       "rank":5,
-      "team":"Queens Park Rangers ",
+      "team":"Queens Park Rangers",
       "played":42,
       "wins":17,
       "draws":12,
@@ -66,7 +66,7 @@
    },
    {
       "rank":6,
-      "team":"Liverpool ",
+      "team":"Liverpool",
       "played":42,
       "wins":16,
       "draws":11,
@@ -79,7 +79,7 @@
    },
    {
       "rank":7,
-      "team":"Sheffield Wednesday ",
+      "team":"Sheffield Wednesday",
       "played":42,
       "wins":15,
       "draws":14,
@@ -92,7 +92,7 @@
    },
    {
       "rank":8,
-      "team":"Tottenham Hotspur ",
+      "team":"Tottenham Hotspur",
       "played":42,
       "wins":16,
       "draws":11,
@@ -105,7 +105,7 @@
    },
    {
       "rank":9,
-      "team":"Manchester City ",
+      "team":"Manchester City",
       "played":42,
       "wins":15,
       "draws":12,
@@ -118,7 +118,7 @@
    },
    {
       "rank":10,
-      "team":"Arsenal ",
+      "team":"Arsenal",
       "played":42,
       "wins":15,
       "draws":11,
@@ -131,7 +131,7 @@
    },
    {
       "rank":11,
-      "team":"Chelsea ",
+      "team":"Chelsea",
       "played":42,
       "wins":14,
       "draws":14,
@@ -144,7 +144,7 @@
    },
    {
       "rank":12,
-      "team":"Wimbledon ",
+      "team":"Wimbledon",
       "played":42,
       "wins":14,
       "draws":12,
@@ -157,7 +157,7 @@
    },
    {
       "rank":13,
-      "team":"Everton ",
+      "team":"Everton",
       "played":42,
       "wins":15,
       "draws":8,
@@ -170,7 +170,7 @@
    },
    {
       "rank":14,
-      "team":"Sheffield United ",
+      "team":"Sheffield United",
       "played":42,
       "wins":14,
       "draws":10,
@@ -183,7 +183,7 @@
    },
    {
       "rank":15,
-      "team":"Coventry City ",
+      "team":"Coventry City",
       "played":42,
       "wins":13,
       "draws":13,
@@ -196,7 +196,7 @@
    },
    {
       "rank":16,
-      "team":"Ipswich Town ",
+      "team":"Ipswich Town",
       "played":42,
       "wins":12,
       "draws":16,
@@ -209,7 +209,7 @@
    },
    {
       "rank":17,
-      "team":"Leeds United ",
+      "team":"Leeds United",
       "played":42,
       "wins":12,
       "draws":15,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Southampton ",
+      "team":"Southampton",
       "played":42,
       "wins":13,
       "draws":11,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Oldham Athletic ",
+      "team":"Oldham Athletic",
       "played":42,
       "wins":13,
       "draws":10,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Crystal Palace ",
+      "team":"Crystal Palace",
       "played":42,
       "wins":11,
       "draws":16,
@@ -261,7 +261,7 @@
    },
    {
       "rank":21,
-      "team":"Middlesbrough ",
+      "team":"Middlesbrough",
       "played":42,
       "wins":11,
       "draws":11,
@@ -274,7 +274,7 @@
    },
    {
       "rank":22,
-      "team":"Nottingham Forest ",
+      "team":"Nottingham Forest",
       "played":42,
       "wins":10,
       "draws":10,

--- a/EPL 1992 - 2015/tables/epl-93-94.json
+++ b/EPL 1992 - 2015/tables/epl-93-94.json
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Sheffield United ",
+      "team":"Sheffield United",
       "played":42,
       "wins":8,
       "draws":18,
@@ -261,7 +261,7 @@
    },
    {
       "rank":21,
-      "team":"Oldham Athletic ",
+      "team":"Oldham Athletic",
       "played":42,
       "wins":9,
       "draws":13,
@@ -274,7 +274,7 @@
    },
    {
       "rank":22,
-      "team":"Swindon Town ",
+      "team":"Swindon Town",
       "played":42,
       "wins":5,
       "draws":15,

--- a/EPL 1992 - 2015/tables/epl-94-95.json
+++ b/EPL 1992 - 2015/tables/epl-94-95.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Blackburn Rovers ",
+      "team":"Blackburn Rovers",
       "played":42,
       "wins":27,
       "draws":8,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Crystal Palace ",
+      "team":"Crystal Palace",
       "played":42,
       "wins":11,
       "draws":12,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Norwich City ",
+      "team":"Norwich City",
       "played":42,
       "wins":10,
       "draws":13,
@@ -261,7 +261,7 @@
    },
    {
       "rank":21,
-      "team":"Leicester City ",
+      "team":"Leicester City",
       "played":42,
       "wins":6,
       "draws":11,
@@ -274,7 +274,7 @@
    },
    {
       "rank":22,
-      "team":"Ipswich Town ",
+      "team":"Ipswich Town",
       "played":42,
       "wins":7,
       "draws":6,

--- a/EPL 1992 - 2015/tables/epl-95-96.json
+++ b/EPL 1992 - 2015/tables/epl-95-96.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Manchester United ",
+      "team":"Manchester United",
       "played":38,
       "wins":25,
       "draws":7,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Manchester City ",
+      "team":"Manchester City",
       "played":38,
       "wins":9,
       "draws":11,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Queens Park Rangers ",
+      "team":"Queens Park Rangers",
       "played":38,
       "wins":9,
       "draws":6,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Bolton Wanderers ",
+      "team":"Bolton Wanderers",
       "played":38,
       "wins":8,
       "draws":5,

--- a/EPL 1992 - 2015/tables/epl-96-97.json
+++ b/EPL 1992 - 2015/tables/epl-96-97.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Manchester United ",
+      "team":"Manchester United",
       "played":38,
       "wins":21,
       "draws":12,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Sunderland ",
+      "team":"Sunderland",
       "played":38,
       "wins":10,
       "draws":10,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Middlesbrough ",
+      "team":"Middlesbrough",
       "played":38,
       "wins":10,
       "draws":12,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Nottingham Forest ",
+      "team":"Nottingham Forest",
       "played":38,
       "wins":6,
       "draws":16,

--- a/EPL 1992 - 2015/tables/epl-97-98.json
+++ b/EPL 1992 - 2015/tables/epl-97-98.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Arsenal ",
+      "team":"Arsenal",
       "played":38,
       "wins":23,
       "draws":9,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Bolton Wanderers ",
+      "team":"Bolton Wanderers",
       "played":38,
       "wins":9,
       "draws":13,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Barnsley ",
+      "team":"Barnsley",
       "played":38,
       "wins":10,
       "draws":5,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Crystal Palace ",
+      "team":"Crystal Palace",
       "played":38,
       "wins":8,
       "draws":9,

--- a/EPL 1992 - 2015/tables/epl-98-99.json
+++ b/EPL 1992 - 2015/tables/epl-98-99.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Manchester United ",
+      "team":"Manchester United",
       "played":38,
       "wins":22,
       "draws":13,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Charlton Athletic ",
+      "team":"Charlton Athletic",
       "played":38,
       "wins":8,
       "draws":12,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Blackburn Rovers ",
+      "team":"Blackburn Rovers",
       "played":38,
       "wins":7,
       "draws":14,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Nottingham Forest ",
+      "team":"Nottingham Forest",
       "played":38,
       "wins":7,
       "draws":9,

--- a/EPL 1992 - 2015/tables/epl-99-00.json
+++ b/EPL 1992 - 2015/tables/epl-99-00.json
@@ -1,7 +1,7 @@
 [
    {
       "rank":1,
-      "team":"Manchester United ",
+      "team":"Manchester United",
       "played":38,
       "wins":28,
       "draws":7,
@@ -222,7 +222,7 @@
    },
    {
       "rank":18,
-      "team":"Wimbledon ",
+      "team":"Wimbledon",
       "played":38,
       "wins":7,
       "draws":12,
@@ -235,7 +235,7 @@
    },
    {
       "rank":19,
-      "team":"Sheffield Wednesday ",
+      "team":"Sheffield Wednesday",
       "played":38,
       "wins":8,
       "draws":7,
@@ -248,7 +248,7 @@
    },
    {
       "rank":20,
-      "team":"Watford ",
+      "team":"Watford",
       "played":38,
       "wins":6,
       "draws":6,


### PR DESCRIPTION
This PR cleans up team names in `/EPL 1992 - 2015/tables/{file}.json`.  The following fixes were performed in team names:
- removed trailing spaces, eg: "Arsenal " -> "Arsenal"
- fixed duplicate names: eg: Arsenal !Arsenal" -> "Arsenal"
